### PR TITLE
Fixed inconsistency in attribute naming and XML documentation

### DIFF
--- a/Base/Components/HealthComponent/HealthComponent.cs
+++ b/Base/Components/HealthComponent/HealthComponent.cs
@@ -44,22 +44,22 @@ public partial class HealthComponent : Node2D
         }
     }
 
-    [Signal]
     /// <summary>
     /// Событие, оповещающее об инициализации компонента с параметрами начального значения и максимального
     /// </summary>
+    [Signal]
     public delegate void HealthInitializedEventHandler(float StartValue, float MaxValue);
 
-    [Signal]
     /// <summary>
     /// Событие, оповещающее об изменении значения компонента
     /// </summary>
+    [Signal]
     public delegate void HealthChangedEventHandler(float delta);
 
-    [Signal]
     /// <summary>
     /// Событие, оповещающее об падении значения здоровья до 0 или меньше 0
     /// </summary>
+    [Signal]
     public delegate void HealthZeroOrBelowEventHandler();
 
 

--- a/Weapon/AnimatedWeapon.cs
+++ b/Weapon/AnimatedWeapon.cs
@@ -76,17 +76,20 @@ public abstract partial class AnimatedWeapon : Node2D
     /// The weapon created and configured the projectile. <br/>
     /// <b>Should be invoked at the end of the <see cref="Shoot"/></b>
     /// </summary>
-    [Signal] public delegate void WeaponShootedEventHandler();
+    [Signal] 
+    public delegate void WeaponShootedEventHandler();
 
     /// <summary>
     /// Оружие начало стрелять. На оружии <b>зажали</b> курок.
     /// </summary>
-    [Signal] public delegate void WeaponStartedShootingEventHandler();
+    [Signal] 
+    public delegate void WeaponStartedShootingEventHandler();
 
     /// <summary>
     /// Оружие перестало стрелять. На оружии <b>отжали</b> курок.
     /// </summary>
-    [Signal] public delegate void WeaponStoppedShootingEventHandler();
+    [Signal] 
+    public delegate void WeaponStoppedShootingEventHandler();
 
     /// <summary>
     /// Один из способов направить оружие в нужном направлении. <br/>

--- a/Weapon/WeaponSettings.cs
+++ b/Weapon/WeaponSettings.cs
@@ -12,7 +12,9 @@ using System;
 /// Уровни и маски для <c>Player</c> и <c>NPC</c>
 /// </code>
 /// </summary>
-[Tool] [GlobalClass] public partial class WeaponSettings : Resource
+[Tool] 
+[GlobalClass] 
+public partial class WeaponSettings : Resource
 {
     [Export] public string DisplayedWeaponName {get; set;}
     [Export] public PackedScene ProjectileScene {get; set;}


### PR DESCRIPTION
Но у меня рука не поворачивается переместить атрибут [Export] для обычных полей на следующую строку